### PR TITLE
feat(disconnectAccounts): #70 Implemented functionality to disconnect accounts

### DIFF
--- a/web/src/app/components/dashboard/dashboard.component.html
+++ b/web/src/app/components/dashboard/dashboard.component.html
@@ -4,7 +4,7 @@
   </div>
   <div class="cards" *ngIf="!isResponseLoading">
     <div class="overview">Overview</div>
-    <app-social-cards [userSocial]="userSocial"></app-social-cards>
+    <app-social-cards [userSocial]="userSocial" (linkAccountRemoved)="reload($event)"></app-social-cards>
   </div>
   <div *ngIf="isResponseLoading" fxLayout fxLayoutAlign="center center">
     <mat-spinner strokeWidth="4"></mat-spinner>

--- a/web/src/app/components/dashboard/dashboard.component.ts
+++ b/web/src/app/components/dashboard/dashboard.component.ts
@@ -31,6 +31,11 @@ export class DashboardComponent implements OnInit {
       this.displayOwnDashboard();
   }
 
+  reload(): void {
+    this.isResponseLoading = true;
+    this.displayOwnDashboard();
+  }
+
   displayOwnDashboard(): void {
     this.userService.getUser()
       .pipe(

--- a/web/src/app/components/navbar/navbar.component.ts
+++ b/web/src/app/components/navbar/navbar.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { AuthService } from 'src/app/services/auth.service';
 import { Router } from '@angular/router';
-import { UserService } from 'src/app/services/user.service';
 
 @Component({
   selector: 'app-navbar',

--- a/web/src/app/components/social-cards/social-cards.component.html
+++ b/web/src/app/components/social-cards/social-cards.component.html
@@ -1,7 +1,10 @@
 <mat-card class="outer-container" fxLayout="row" fxLayoutGap="20px">
   <mat-card fxFlex="25">
     <mat-card-content *ngIf="userSocial.github">
-      <mat-icon svgIcon="github" class="github"></mat-icon>
+      <div fxLayout="row" fxLayoutAlign="space-between">
+        <mat-icon svgIcon="github" class="github"></mat-icon>
+        <button mat-button (click)="disconnectAccount('github')">Disconnect</button>
+      </div>
       <div fxLayout class="stats-wrapper">
         <div fxLayout="column" fxFlex="33">
           <span class="stats-display">{{ userSocial.github.followers }}</span>
@@ -21,7 +24,10 @@
   </mat-card>
   <mat-card fxFlex="25">
     <mat-card-content *ngIf="userSocial.twitter">
-      <mat-icon svgIcon="twitter" class="twitter"></mat-icon>
+      <div fxLayout="row" fxLayoutAlign="space-between">
+        <mat-icon svgIcon="twitter" class="twitter"></mat-icon>
+        <button mat-button (click)="disconnectAccount('twitter')">Disconnect</button>
+      </div>
       <div fxLayout class="stats-wrapper">
         <div fxLayout="column" fxFlex="33">
           <span class="stats-display">{{ userSocial.twitter.followers }}</span>
@@ -44,7 +50,10 @@
   </mat-card>
   <mat-card fxFlex="25">
     <mat-card-content *ngIf="userSocial.youtube">
-      <mat-icon svgIcon="youtube-fill" class="youtube"></mat-icon>
+      <div fxLayout="row" fxLayoutAlign="space-between">
+        <mat-icon svgIcon="youtube-fill" class="youtube"></mat-icon>
+        <button mat-button>Disconnect</button>
+      </div>
       <div fxLayout class="stats-wrapper">
         <div fxLayout="column" fxFlex="33">
           <span class="stats-display">{{ userSocial.youtube.followers }}</span>
@@ -67,7 +76,10 @@
   </mat-card>
   <mat-card fxFlex="25">
     <mat-card-content *ngIf="userSocial.instagram">
-      <mat-icon svgIcon="instagram" class="instagram"></mat-icon>
+      <div fxLayout="row" fxLayoutAlign="space-between">
+        <mat-icon svgIcon="instagram" class="instagram"></mat-icon>
+        <button mat-button>Disconnect</button>
+      </div>
       <div fxLayout class="stats-wrapper">
         <div fxLayout="column" fxFlex="33">
           <span class="stats-display">{{ userSocial.instagram.followers }}</span>

--- a/web/src/app/components/social-cards/social-cards.component.ts
+++ b/web/src/app/components/social-cards/social-cards.component.ts
@@ -1,10 +1,9 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { UserSocial } from 'src/app/models/userSocial.model';
-import { AuthService } from 'src/app/services/auth.service';
 import { UserService } from 'src/app/services/user.service';
 import { User } from 'src/app/models/user.model';
 import { AccountsService } from 'src/app/services/accounts.service';
-
+import { Router } from '@angular/router';
 @Component({
   selector: 'app-social-cards',
   templateUrl: './social-cards.component.html',
@@ -13,10 +12,12 @@ import { AccountsService } from 'src/app/services/accounts.service';
 export class SocialCardsComponent implements OnInit {
 
   @Input() userSocial: UserSocial;
+  @Output() linkAccountRemoved = new EventEmitter();
 
   constructor(
     private userService: UserService,
     private accountsService: AccountsService,
+    private router: Router,
   ) { }
 
   ngOnInit() { }
@@ -48,6 +49,17 @@ export class SocialCardsComponent implements OnInit {
       });
   }
 
+  disconnectAccount(provider: string): void {
+    this.accountsService.disconnectAccount(provider)
+      .subscribe((value) => {
+        if (value) {
+          this.linkAccountRemoved.emit('reload');
+          return;
+        }
+        this.router.navigate(['/login']);
+      });
+  }
+
   saveSecondaryUser(user: User, provider): void {
     this.userService.saveLinkUser(user, provider)
       .subscribe((response) => {
@@ -67,7 +79,7 @@ export class SocialCardsComponent implements OnInit {
           console.error('Error in verifying if the user is an existing one');
           return;
         }
-        const userSocial = { ...socialRecord, ...response };
+        const userSocial = { ...response, ...socialRecord };
         this.userService.addSocialProvider(userSocial)
           .subscribe((result) => {
             console.log('result', result); // TODO: Will remove in future

--- a/web/src/app/components/social-cards/social-cards.component.ts
+++ b/web/src/app/components/social-cards/social-cards.component.ts
@@ -4,6 +4,9 @@ import { UserService } from 'src/app/services/user.service';
 import { User } from 'src/app/models/user.model';
 import { AccountsService } from 'src/app/services/accounts.service';
 import { Router } from '@angular/router';
+import { PROVIDERS } from '../../../constant';
+
+
 @Component({
   selector: 'app-social-cards',
   templateUrl: './social-cards.component.html',
@@ -24,10 +27,10 @@ export class SocialCardsComponent implements OnInit {
 
   connectAccount(provider: string): void {
     switch (provider) {
-      case 'github':
+      case PROVIDERS.GITHUB:
         this.addGithubAccount();
         break;
-      case 'twitter':
+      case PROVIDERS.TWITTER:
         this.addTwitterAccount();
         break;
       default:

--- a/web/src/app/components/social-cards/social-cards.component.ts
+++ b/web/src/app/components/social-cards/social-cards.component.ts
@@ -51,8 +51,8 @@ export class SocialCardsComponent implements OnInit {
 
   disconnectAccount(provider: string): void {
     this.accountsService.disconnectAccount(provider)
-      .subscribe((value) => {
-        if (value) {
+      .subscribe((isConnected) => {
+        if (isConnected) {
           this.linkAccountRemoved.emit('reload');
           return;
         }

--- a/web/src/app/services/accounts.service.ts
+++ b/web/src/app/services/accounts.service.ts
@@ -6,6 +6,7 @@ import { Observable, from } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 import { User } from '../models/user.model';
 import { ErrorService } from './error.service';
+import { UserService } from 'src/app/services/user.service';
 
 @Injectable({
   providedIn: 'root'
@@ -16,6 +17,7 @@ export class AccountsService {
     private firebaseAuth: AngularFireAuth,
     private authService: AuthService,
     private errorService: ErrorService,
+    private userService: UserService
   ) { }
 
   linkWithTwitter(): Observable<User> {
@@ -34,5 +36,29 @@ export class AccountsService {
         map((user) => this.authService.formatUserResponse(user, providerLabel)),
         catchError((error) => this.errorService.logError(error)),
       );
+  }
+
+  disconnectAccount(provider: string): Observable<boolean> {
+    const providerData = this.firebaseAuth.auth.currentUser.providerData;
+    const userId = this.firebaseAuth.auth.currentUser.uid;
+    if (providerData[0].providerId === `${provider}.com`) {
+      return this.userService.removeUser(userId)
+        .pipe(
+          map(() => {
+            this.firebaseAuth.auth.currentUser.delete();
+            return false;   // to find whether it is primary or linked account.
+          }),
+          catchError((err) => this.errorService.logError(err))
+        );
+    } else {
+      return this.userService.removeLinkUser(userId, provider)
+        .pipe(
+          map(() => {
+            this.firebaseAuth.auth.currentUser.unlink(`${provider}.com`);
+            return true;
+          }),
+          catchError((err) => this.errorService.logError(err)),
+        );
+    }
   }
 }

--- a/web/src/app/services/auth.service.ts
+++ b/web/src/app/services/auth.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
 import { AngularFireAuth } from 'angularfire2/auth';
-import { AngularFirestore } from 'angularfire2/firestore';
+import {
+  AngularFirestore,
+} from 'angularfire2/firestore';
 import * as firebase from 'firebase/app';
 import { Observable, from, of } from 'rxjs';
 import { map, catchError, switchMap } from 'rxjs/operators';

--- a/web/src/app/services/auth.service.ts
+++ b/web/src/app/services/auth.service.ts
@@ -8,6 +8,7 @@ import { Observable, from, of } from 'rxjs';
 import { map, catchError, switchMap } from 'rxjs/operators';
 import { ErrorService } from './error.service';
 import { User } from '../models/user.model';
+import { PROVIDERS } from '../../constant';
 
 @Injectable()
 export class AuthService {
@@ -61,9 +62,9 @@ export class AuthService {
       return null;
     }
     switch (provider) {
-      case 'github':
+      case PROVIDERS.GITHUB:
         return normalisedUser = this.normaliseGithubUser(response);
-      case 'twitter':
+      case PROVIDERS.TWITTER:
         return normalisedUser = this.normaliseTwitterUser(response);
       default:
         return null;

--- a/web/src/app/services/user.service.ts
+++ b/web/src/app/services/user.service.ts
@@ -10,6 +10,7 @@ import { AuthService } from './auth.service';
 import { User } from '../models/user.model';
 import { UserSocial } from '../models/userSocial.model';
 import { Router } from '@angular/router';
+import { PROVIDERS } from '../../constant';
 
 @Injectable()
 export class UserService {
@@ -37,10 +38,10 @@ export class UserService {
   removeLinkUser(id: string, provider: string): Observable<null> {
     let user;
     switch (provider) {
-      case 'github':
+      case PROVIDERS.GITHUB:
         user = { github: null };
         break;
-      case 'twitter':
+      case PROVIDERS.TWITTER:
         user = { twitter: null };
         break;
       default:
@@ -106,10 +107,10 @@ export class UserService {
   addRefID(user: User, provider): UserSocial {
     let normalisedResponse;
     switch (provider) {
-      case 'github':
+      case PROVIDERS.GITHUB:
         normalisedResponse = { ...user.github.additionalUserInfo.profile, userId: user.uid };
         break;
-      case 'twitter':
+      case PROVIDERS.TWITTER:
         normalisedResponse = { ...user.twitter.additionalUserInfo.profile, userId: user.uid };
         break;
       default:

--- a/web/src/app/services/user.service.ts
+++ b/web/src/app/services/user.service.ts
@@ -26,6 +26,32 @@ export class UserService {
     this.user = this.db.collection('user');
   }
 
+  removeUser(id: string): Observable<null> {
+    return from(this.userSocial.doc(id).delete())
+      .pipe(
+        map(() => this.user.doc(id).delete()),
+        catchError((err) => this.errorService.logError(err))
+      );
+  }
+
+  removeLinkUser(id: string, provider: string): Observable<null> {
+    let user;
+    switch (provider) {
+      case 'github':
+        user = { github: null };
+        break;
+      case 'twitter':
+        user = { twitter: null };
+        break;
+      default:
+        break;
+    }
+    return from(this.userSocial.doc(id).update(user))
+      .pipe(
+        map(() => this.user.doc(id).update(user)),
+        catchError((err) => this.errorService.logError(err))
+      );
+  }
 
   saveUser(user: User, provider): Observable<UserSocial> {
     return from(this.user.doc(user.uid).set(user))

--- a/web/src/constant.ts
+++ b/web/src/constant.ts
@@ -1,0 +1,4 @@
+export const PROVIDERS = {
+  GITHUB: 'github',
+  TWITTER: 'twitter'
+};


### PR DESCRIPTION
- Added disconnect buttons on the social cards.

- Implemented functionality to differentiate between connected and primary account.

- Redirected to login and deleted all the connected accounts if the primary account is disconnected.

- Refreshed the dashboard if one of the connected accounts is disconnected.
![Screen Shot 2019-05-07 at 5 19 24 PM](https://user-images.githubusercontent.com/36227360/57297103-57414980-70ec-11e9-8eb8-4f242e8454c0.png)
